### PR TITLE
Add proto of OpenSergo universal transport service

### DIFF
--- a/opensergo/proto/transport/v1/transport.proto
+++ b/opensergo/proto/transport/v1/transport.proto
@@ -61,6 +61,9 @@ message SubscribeRequest {
 
   // client-to-server response status
   Status status = 6;
+  
+  string identifier = 7;
+  string request_id = 8;
 }
 
 message ControlPlaneDesc {
@@ -79,9 +82,15 @@ message SubscribeResponse {
   string namespace = 4;
   string app = 5;
   string kind = 6;
-  repeated google.protobuf.Any data = 7;
+  DataWithVersion dataWithVersion = 7;
 
   ControlPlaneDesc control_plane = 8;
+  string response_id = 9;
+}
+
+message DataWithVersion {
+  repeated google.protobuf.Any data = 1;
+  int64 version = 2;
 }
 
 // OpenSergo Universal Transport Service (state-of-the-world)

--- a/opensergo/proto/transport/v1/transport.proto
+++ b/opensergo/proto/transport/v1/transport.proto
@@ -1,0 +1,90 @@
+// Copyright 2022, OpenSergo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package io.opensergo.proto.transport.v1;
+
+option java_package = "io.opensergo.proto.transport.v1";
+option java_outer_classname = "OpenSergoTransportProto";
+option java_multiple_files = true;
+option go_package = "github.com/opensergo/opensergo-control-plane/proto/transport/v1";
+
+import "google/protobuf/any.proto";
+
+// Common
+
+message Status {
+  int32 code = 1;
+  string message = 2;
+  repeated google.protobuf.Any details = 3;
+}
+
+enum SubscribeOpType {
+  SUBSCRIBE = 0;
+  UNSUBSCRIBE = 1;
+}
+
+// SubscribeRequest
+
+message SubscribeLabelKV {
+  string key = 1;
+  string value = 2;
+}
+
+message SubscribeRequestTarget {
+  string namespace = 1;
+  string app = 2;
+  repeated SubscribeLabelKV labels = 3;
+  repeated string kinds = 4;
+}
+
+message SubscribeRequest {
+  SubscribeRequestTarget target = 1;
+  SubscribeOpType op_type = 2;
+
+  string version_info = 3;
+  string response_ack = 4;
+
+  repeated google.protobuf.Any attachments = 5;
+
+  // client-to-server response status
+  Status status = 6;
+}
+
+message ControlPlaneDesc {
+  string identifier = 1;
+}
+
+// SubscribeResponse
+
+message SubscribeResponse {
+  Status status = 1;
+
+  // The version of the response data.
+  string version_info = 2;
+  string ack = 3;
+
+  string namespace = 4;
+  string app = 5;
+  string kind = 6;
+  repeated google.protobuf.Any data = 7;
+
+  ControlPlaneDesc control_plane = 8;
+}
+
+// OpenSergo Universal Transport Service (state-of-the-world)
+service OpenSergoUniversalTransportService {
+  rpc SubscribeConfig(stream SubscribeRequest) returns (stream SubscribeResponse);
+}

--- a/opensergo/proto/transport/v1/transport.proto
+++ b/opensergo/proto/transport/v1/transport.proto
@@ -19,7 +19,7 @@ package io.opensergo.proto.transport.v1;
 option java_package = "io.opensergo.proto.transport.v1";
 option java_outer_classname = "OpenSergoTransportProto";
 option java_multiple_files = true;
-option go_package = "github.com/opensergo/opensergo-control-plane/proto/transport/v1";
+option go_package = "github.com/opensergo/opensergo-control-plane/pkg/proto/transport/v1";
 
 import "google/protobuf/any.proto";
 
@@ -54,16 +54,14 @@ message SubscribeRequest {
   SubscribeRequestTarget target = 1;
   SubscribeOpType op_type = 2;
 
-  string version_info = 3;
-  string response_ack = 4;
+  string response_ack = 3;
 
-  repeated google.protobuf.Any attachments = 5;
+  repeated google.protobuf.Any attachments = 4;
 
   // client-to-server response status
-  Status status = 6;
-  
-  string identifier = 7;
-  string request_id = 8;
+  Status status = 5;
+  string identifier = 6;
+  string request_id = 7;
 }
 
 message ControlPlaneDesc {
@@ -75,17 +73,15 @@ message ControlPlaneDesc {
 message SubscribeResponse {
   Status status = 1;
 
-  // The version of the response data.
-  string version_info = 2;
-  string ack = 3;
+  string ack = 2;
 
-  string namespace = 4;
-  string app = 5;
-  string kind = 6;
-  DataWithVersion dataWithVersion = 7;
+  string namespace = 3;
+  string app = 4;
+  string kind = 5;
+  DataWithVersion dataWithVersion = 6;
 
-  ControlPlaneDesc control_plane = 8;
-  string response_id = 9;
+  ControlPlaneDesc control_plane = 7;
+  string response_id = 8;
 }
 
 message DataWithVersion {


### PR DESCRIPTION
Add proto of *OpenSergo universal transport service*.

Resolves #1

(English version TBD...)

---

OpenSergo universal transport service 作为 OpenSergo 控制面与数据面之间的传输协议，可以承载 OpenSergo 任意类型 config 的增量/全量订阅与传输能力。部分地方借鉴了 xDS 的设计。

在全量推送 service 模型中，`SubscribeConfig` 承载客户端发起配置订阅请求，服务端下推配置的链路。